### PR TITLE
PID Heading Correction

### DIFF
--- a/src/org/usfirst/frc/team88/robot/subsystems/Drive.java
+++ b/src/org/usfirst/frc/team88/robot/subsystems/Drive.java
@@ -5,6 +5,7 @@ import org.usfirst.frc.team88.robot.RobotMap;
 import org.usfirst.frc.team88.robot.commands.DriveSplitArcade;
 import org.usfirst.frc.team88.robot.commands.DriveTank;
 import org.usfirst.frc.team88.robot.commands.DriveTank2;
+import org.usfirst.frc.team88.robot.util.PIDHeadingCorrection;
 
 import com.ctre.phoenix.motorcontrol.ControlMode;
 import com.ctre.phoenix.motorcontrol.FeedbackDevice;
@@ -49,7 +50,12 @@ public class Drive extends Subsystem implements PIDOutput {
 	private final static double ROTATE_TOLERANCE = 3.0;
 	private final static double ROTATE_MAX = 0.15;
 	private final static double ROTATE_MIN = 0.05;
-
+	private final static double HEADING_P = 0.008;
+	private final static double HEADING_I = 0.0;
+	private final static double HEADING_D = 0.0;
+	private final static double HEADING_F = 0.0;
+	private final static double HEADING_TOLERANCE = 0.5;
+	
 	private AHRS navX;
 	private TalonSRX leftTalon;
 	private TalonSRX rightTalon;
@@ -57,10 +63,10 @@ public class Drive extends Subsystem implements PIDOutput {
 	private VictorSPX[] rightVictors;
 
 	private int count;
-	private double heading;
-	private boolean stabilize;
 
 	public PIDController rotateController;
+	private PIDController headingController;
+	private PIDHeadingCorrection headingCorrection;
 
 	public Drive() {
 		// init navX
@@ -72,6 +78,15 @@ public class Drive extends Subsystem implements PIDOutput {
 		rotateController.setOutputRange(-1.0, 1.0);
 		rotateController.setAbsoluteTolerance(ROTATE_TOLERANCE);
 		rotateController.setContinuous(true);
+
+		// init headingController
+		headingCorrection = new PIDHeadingCorrection();
+		
+		headingController = new PIDController(HEADING_P, HEADING_I, HEADING_D, HEADING_F, navX, headingCorrection);
+		headingController.setInputRange(-180.0f, 180.0f);
+		headingController.setOutputRange(-1.0, 1.0);
+		headingController.setAbsoluteTolerance(HEADING_TOLERANCE);
+		headingController.setContinuous(true);
 
 		// init talons
 		leftTalon = new TalonSRX(RobotMap.leftTalonMaster);
@@ -134,7 +149,8 @@ public class Drive extends Subsystem implements PIDOutput {
 		resetEncoders();
 		navX.zeroYaw();
 		count = 0;
-		stabilize = false;
+		headingController.reset();
+		headingController.disable();
 	}
 
 	public void wheelSpeed(double left, double right) {
@@ -200,15 +216,15 @@ public class Drive extends Subsystem implements PIDOutput {
 		SmartDashboard.putNumber("Curve", curve);
 		SmartDashboard.putNumber("Magnitude", outputMagnitude);
 		SmartDashboard.putNumber("Count", count);
-		SmartDashboard.putBoolean("Stabilize", stabilize);
+		SmartDashboard.putBoolean("Stabilize", headingController.isEnabled());
 
 		if (outputMagnitude == 0) {
-			stabilize = false;
+			headingController.disable();
 			count = 0;
-		} else if (stabilize && curve == 0) {
-			curve = (heading - getYaw()) * 0.008;
-		} else if (stabilize) {
-			stabilize = false;
+		} else if (headingController.isEnabled() && curve == 0) {
+			curve = headingCorrection.getHeadingCorrection();
+		} else if (headingController.isEnabled()) {
+			headingController.disable();
 			count = 0;
 		}
 
@@ -216,7 +232,7 @@ public class Drive extends Subsystem implements PIDOutput {
 			curve = curve * Math.signum(outputMagnitude);
 		}
 
-		if (Math.abs(outputMagnitude) < 0.10) {
+		if ((outputMagnitude == 0) && (Math.abs(getAvgSpeed()) < 0.1 * MAX_SPEED)) {
 			leftOutput = curve * 0.5;
 			rightOutput = -curve * 0.5;
 		} else if (curve < 0) {
@@ -237,8 +253,9 @@ public class Drive extends Subsystem implements PIDOutput {
 			rightOutput = outputMagnitude / ratio;
 		} else {
 			if (count++ > 4) {
-				stabilize = true;
-				heading = getYaw();
+				headingController.reset();
+				headingController.enable();
+				headingController.setSetpoint(getYaw());
 			}
 
 			leftOutput = outputMagnitude;

--- a/src/org/usfirst/frc/team88/robot/util/PIDHeadingCorrection.java
+++ b/src/org/usfirst/frc/team88/robot/util/PIDHeadingCorrection.java
@@ -1,0 +1,16 @@
+package org.usfirst.frc.team88.robot.util;
+import edu.wpi.first.wpilibj.PIDOutput;
+
+public class PIDHeadingCorrection implements PIDOutput {
+
+	private double headingCorrection;
+	@Override
+	public void pidWrite(double output) {
+		headingCorrection = output;
+	}
+	
+	public double getHeadingCorrection() {
+		return headingCorrection;
+	}
+
+}


### PR DESCRIPTION
This changes our heading correction from bang-bang style (ie, only "P"roportional adjustment) to PID style. The constants are initialized with the "P" value we were using in bang-bang style, but should be tuned. Likely this will mean a large D, and maybe a small amount of I.

I also added a change to try to address the "spin-out effect" that can occur when you stop after driving at high speed. I'm not sure this will work or if it will have negative effects on spinning in place, so that line might change back.